### PR TITLE
Updated the dashboard for network metrics to show network traffic

### DIFF
--- a/dashboards/default_dashboard.json
+++ b/dashboards/default_dashboard.json
@@ -265,7 +265,7 @@
           },
           "targets": [
             {
-              "target": "rackspace.monitoring.entities.*.checks.agent.network.*.rx_bytes"
+              "target": "derivative(rackspace.monitoring.entities.*.checks.agent.network.*.rx_bytes)"
             }
           ],
           "aliasColors": {},
@@ -327,7 +327,7 @@
           },
           "targets": [
             {
-              "target": "rackspace.monitoring.entities.*.checks.agent.network.*.tx_bytes"
+              "target": "derivative(rackspace.monitoring.entities.*.checks.agent.network.*.tx_bytes)"
             }
           ],
           "aliasColors": {},
@@ -381,6 +381,6 @@
     "list": [],
     "enable": false
   },
-  "refresh": "5s",
+  "refresh": "10s",
   "version": 6
 }


### PR DESCRIPTION
Use derivative function on the network metrics data.

Before
<img width="1353" alt="before" src="https://cloud.githubusercontent.com/assets/18065/9942726/8cd652d4-5d31-11e5-8f46-37e8a308e9e7.png">

After

<img width="1364" alt="after" src="https://cloud.githubusercontent.com/assets/18065/9942731/9421028c-5d31-11e5-88d0-6079acdd1979.png">
