### PR TITLE
modify yaml to use pip install for blueflood source,

### DIFF
--- a/grafana-cloud-metrics.yaml
+++ b/grafana-cloud-metrics.yaml
@@ -230,8 +230,10 @@ resources:
               disable_existing_loggers: true
               handlers:
                 file:
-                  class: logging.FileHandler
+                  class: logging.handlers.RotatingFileHandler
                   filename: /var/log/graphite-api.log
+                  backupCount: 2
+                  maxBytes: 536870912
               loggers:
                 graphite_api:
                   handlers:

--- a/grafana-cloud-metrics.yaml
+++ b/grafana-cloud-metrics.yaml
@@ -208,14 +208,11 @@ resources:
             /etc/init.d/nginx restart
             pip install gunicorn
             pip install --upgrade "git+http://github.com/rackerlabs/graphite-api.git@george/fetch_multi_with_patches"
-            git -C /tmp clone https://github.com/rackerlabs/blueflood.git
-            git -C /tmp/blueflood checkout master
-            cd /tmp/blueflood/contrib/graphite
-            python setup.py install
+            pip install --upgrade blueflood-graphite-finder
             cat > /etc/graphite-api.yaml << EOL
             search_index: /dev/null
             finders:
-              - blueflood.TenantBluefloodFinder
+              - blueflood_graphite_finder.blueflood.TenantBluefloodFinder
             functions:
               - graphite_api.functions.SeriesFunctions
               - graphite_api.functions.PieFunctions
@@ -224,11 +221,36 @@ resources:
               tenant: rax_tenant
               username: rax_username
               apikey: rax_apikey
-              authentication_module: rax_auth
+              authentication_module: blueflood_graphite_finder.rax_auth
               authentication_class: BluefloodAuth
               urls:
                 - http://iad.metrics.api.rackspacecloud.com
+            logging:
+              version: 1
+              disable_existing_loggers: true
+              handlers:
+                file:
+                  class: logging.FileHandler
+                  filename: /var/log/graphite-api.log
+              loggers:
+                graphite_api:
+                  handlers:
+                    - file
+                  propagate: true
+                  level: INFO
+                blueflood_finder:
+                  handlers:
+                    - file
+                  propagate: true
+                  level: INFO
+                root:
+                  handlers:
+                    - file
+                  propagate: true
+                  level: INFO
             EOL
+            git -C /tmp clone https://github.com/rackerlabs/blueflood.git
+            git -C /tmp/blueflood checkout master
             cd /usr/share/nginx/grafana/plugins
             mkdir datasource
             cp -r /tmp/blueflood/contrib/grafana/grafana_1.x/blueflood ./datasource

--- a/grafana-cloud-metrics.yaml
+++ b/grafana-cloud-metrics.yaml
@@ -227,29 +227,23 @@ resources:
                 - http://iad.metrics.api.rackspacecloud.com
             logging:
               version: 1
-              disable_existing_loggers: true
               handlers:
-                file:
+                blueflood_finder_loghandler:
                   class: logging.handlers.RotatingFileHandler
-                  filename: /var/log/graphite-api.log
+                  filename: /var/log/blueflood-graphite-finder.log
+                  formatter: default
                   backupCount: 2
                   maxBytes: 536870912
               loggers:
-                graphite_api:
-                  handlers:
-                    - file
-                  propagate: true
-                  level: INFO
                 blueflood_finder:
                   handlers:
-                    - file
+                    - blueflood_finder_loghandler
                   propagate: true
                   level: INFO
-                root:
-                  handlers:
-                    - file
-                  propagate: true
-                  level: INFO
+              formatters:
+                default:
+                  format: '%(asctime)s %(levelname)-8s %(name)-15s %(message)s'
+                  datefmt: '%Y-%m-%d %H:%M:%S'
             EOL
             git -C /tmp clone https://github.com/rackerlabs/blueflood.git
             git -C /tmp/blueflood checkout master


### PR DESCRIPTION
**What:**

Modify grafana-cloud-metrics.yaml so that we use the new blueflood-graphite-finder package in pypi as the graphite-api source, instead of having to git clone the blueflood project and manually install.

Also added logging for graphite-api.

