### PR TITLE
modify graphite-api to install from rackerlabs

### DIFF
--- a/grafana-cloud-metrics.yaml
+++ b/grafana-cloud-metrics.yaml
@@ -207,7 +207,7 @@ resources:
             ln -s /etc/nginx/sites-available/grafana /etc/nginx/sites-enabled/grafana
             /etc/init.d/nginx restart
             pip install gunicorn
-            pip install --upgrade "git+http://github.com/rackerlabs/graphite-api.git@george/fetch_multi_with_patches"
+            pip install --upgrade "git+http://github.com/rackerlabs/graphite-api.git@1.1.3-rax.1"
             pip install --upgrade blueflood-graphite-finder
             cat > /etc/graphite-api.yaml << EOL
             search_index: /dev/null


### PR DESCRIPTION
# What
change graphite-api install source to use newly rebased rackerlabs/graphite-api tag 1.1.3-rax.1

# Why
We were using an older diverged fork of brutasse's graphite-api, which we reforked and rebased to official version 1.1.3, and add grafana's annotation support to it for tag 1.1.3-rax.1.  This will add support for grafana 3.0 integration.