### PR TITLE
enable ufw with ssh, http, and https

### DIFF
--- a/grafana-cloud-metrics.yaml
+++ b/grafana-cloud-metrics.yaml
@@ -304,6 +304,10 @@ resources:
             url=https://monitoring.api.rackspacecloud.com/v1.0
             EOL
             start graphite-api
+            ufw enable
+            ufw allow ssh
+            ufw allow http
+            ufw allow https
           params:
             es_version: { get_param: es_version }
             gr_version: { get_param: gr_version }


### PR DESCRIPTION
# What

Enable ufw (firewall) and allow only ssh, http, and https ports from anywhere.

# Why

Make server more secure by default and to streamline managed cloud servers who would have ufw enabled by default with http and https restricted.